### PR TITLE
Make checkrun failure return 'neutral' status

### DIFF
--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -458,7 +458,7 @@ func (g *GittufApp) handlePullRequest(ctx context.Context, event *github.PullReq
 				title = "PR is mergeable!"
 				summary = "Sufficient approvals have been submitted for the PR to be mergeable."
 			} else {
-				conclusion = "failure"
+				conclusion = "neutral"
 				title = "PR is not mergeable"
 				summary = "More approvals are necessary for the PR to be mergeable."
 			}
@@ -526,7 +526,7 @@ func (g *GittufApp) handlePullRequest(ctx context.Context, event *github.PullReq
 			title = "PR is mergeable!"
 			summary = "Sufficient approvals have been submitted for the PR to be mergeable."
 		} else {
-			conclusion = "failure"
+			conclusion = "neutral"
 			title = "PR is not mergeable"
 			summary = "More approvals are necessary for the PR to be mergeable."
 		}
@@ -696,7 +696,7 @@ func (g *GittufApp) handlePullRequestReview(ctx context.Context, event *github.P
 		title = "PR is mergeable!"
 		summary = "Sufficient approvals have been submitted for the PR to be mergeable."
 	} else {
-		conclusion = "failure"
+		conclusion = "neutral"
 		title = "PR is not mergeable"
 		summary = "More approvals are necessary for the PR to be mergeable."
 	}


### PR DESCRIPTION
Currently, setting failure as a status may be more blocking than desired while we address edge cases and fix bugs with verifying mergeability of a PR. This commit, therefore, updates the checkrun to return a "neutral" status so that the information is still available while not acting in a blocking manner.