### PR TITLE
iac: add missing ci bindings, use app service account for cloud run.

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -50,7 +50,10 @@ jobs:
           echo "IMAGE_DIGEST=$digest" >> "$GITHUB_OUTPUT"
 
       - name: Deploy image
-        uses: google-github-actions/deploy-cloudrun@v2
-        with:
-          service: app
-          image: "${IMAGE_DIGEST}"
+        run: |
+          gcloud run deploy app \
+            --image "${IMAGE_DIGEST}" \
+            --region us-central1 \
+            --allow-unauthenticated \
+            --service-account gittuf-app@gittuf-451517.iam.gserviceaccount.com \
+            --project gittuf-451517

--- a/iac/app.tf
+++ b/iac/app.tf
@@ -1,0 +1,9 @@
+data "google_service_account" "github-app-sa" {
+  account_id = "gittuf-app@gittuf-451517.iam.gserviceaccount.com"
+}
+
+resource "google_service_account_iam_member" "service_account_user" {
+  service_account_id = data.google_service_account.github-app-sa.id
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${module.github-ci-gsa.email}"
+}

--- a/iac/workload-identity.tf
+++ b/iac/workload-identity.tf
@@ -30,3 +30,9 @@ resource "google_project_iam_member" "ci-run-developer" {
   role    = "roles/run.developer"
   member  = "serviceAccount:${module.github-ci-gsa.email}"
 }
+
+resource "google_project_iam_member" "ci-artifact-registry-writer" {
+  project = var.project
+  role    = "roles/artifactregistry.writer"
+  member  = "serviceAccount:${module.github-ci-gsa.email}"
+}


### PR DESCRIPTION
Needs to use gcloud directly because the cloud run github action doesn't allow you to use a non-default GCP service account.