### PR TITLE
deploy: use GITHUB_ENV instead of GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -47,7 +47,7 @@ jobs:
           KO_DEFAULTBASEIMAGE: "cgr.dev/chainguard/git:latest"
         run: |
           digest=$(ko build .)
-          echo "IMAGE_DIGEST=$digest" >> "$GITHUB_OUTPUT"
+          echo "IMAGE_DIGEST=$digest" >> "$GITHUB_ENV"
 
       - name: Deploy image
         uses: google-github-actions/deploy-cloudrun@v2


### PR DESCRIPTION
GITHUB_OUT sets the output in the github actions output context, the GITHUB_ENV sets the value in the runners environment.

https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables