### PR TITLE
Remove single quotes around link to review

### DIFF
--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -681,7 +681,7 @@ func (g *GittufApp) handlePullRequestReview(ctx context.Context, event *github.P
 			return err
 		}
 
-		message = fmt.Sprintf("Observed dismissal of prior approval '%s' issued by %s (@%s)", event.GetReview().GetHTMLURL(), reviewerIdentifier, reviewer.GetLogin())
+		message = fmt.Sprintf("Observed dismissal of prior approval %s issued by %s (@%s)", event.GetReview().GetHTMLURL(), reviewerIdentifier, reviewer.GetLogin())
 	}
 
 	if err := gitRepo.Push("origin", []string{"refs/gittuf/*"}); err != nil {


### PR DESCRIPTION
The quotes look weird given how GitHub formats the review link. See https://github.com/gittuf/gittuf/pull/992#issuecomment-2899306345 for an example.