### PR TITLE
Use a config value to choose whether to use the github API

### DIFF
--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -99,6 +99,10 @@ type EnvConfig struct {
 	// on PRs where prior approvals do not hold when the base branch is
 	// affected by a push or a merge.
 	CommentOnAffectedPRs bool `envconfig:"COMMENT_ON_AFFECTED_PRS" default:"false"`
+
+	// UseGitHubAPI indicates whether to use the GitHub API for certain actions
+	// like determining the target tree for a merge.
+	UseGitHubAPI bool `envconfig:"USE_GITHUB_API" default:"false"`
 }
 
 type GittufApp struct {
@@ -747,7 +751,16 @@ func (g *GittufApp) handlePullRequestReview(ctx context.Context, event *github.P
 			return nil
 		}
 
-		if err := repo.AddGitHubPullRequestApprover(ctx, signer, owner, repository, pullRequestNumber, event.GetReview().GetID(), reviewerIdentifier, true, githubopts.WithGitHubBaseURL(g.Params.GitHubURL), githubopts.WithGitHubTokenSource(transport), githubopts.WithRSLEntry()); err != nil {
+		opts := []githubopts.Option{
+			githubopts.WithGitHubBaseURL(g.Params.GitHubURL),
+			githubopts.WithGitHubTokenSource(transport),
+			githubopts.WithRSLEntry(),
+		}
+		if g.Params.UseGitHubAPI {
+			opts = append(opts, githubopts.WithUseGitHubAPI())
+		}
+
+		if err := repo.AddGitHubPullRequestApprover(ctx, signer, owner, repository, pullRequestNumber, event.GetReview().GetID(), reviewerIdentifier, true, opts...); err != nil {
 			log.Default().Printf("Unable to create pull request approval attestation: %v", err)
 			return err
 		}


### PR DESCRIPTION
## Description

<!-- Enter a description of what your pull request does. -->

This is a follow up to a previous PR in gittuf/gittuf where we allowed configuring whether to use the API response or not for merge trees. In the app, this makes it configurable.

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [ ] I **did not** use generative AI at all in making the content of this pull
  request.
- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

<!-- If you used generative AI, you must briefly describe how you used it, e.g.
you copied output directly from an LLM, you used AI to draft code/documentation
but made significant manual edits, etc.-->

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [ ] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
